### PR TITLE
Continue achievements init after an error

### DIFF
--- a/Source/OnlineSubsystemGOG/Private/Achievements/AchievementsInterfaceGOG.cpp
+++ b/Source/OnlineSubsystemGOG/Private/Achievements/AchievementsInterfaceGOG.cpp
@@ -388,6 +388,7 @@ bool FOnlineAchievementsGOG::UpdateAchievementDescriptions()
 	cachedAchievementDescriptions.Reserve(AchievementsCount());
 
 	std::array<char, MAX_ACHIVEMENTS_BUFFER_SIZE> achievementInfoBuffer;
+	bool success = true;
 
 	for (const auto& achievementID : achievementIDs)
 	{
@@ -399,7 +400,8 @@ bool FOnlineAchievementsGOG::UpdateAchievementDescriptions()
 		{
 			UE_LOG_ONLINE_ACHIEVEMENTS(Error, TEXT("Failed to read achievement title: achievementID='%s'; %s; %s"),
 				*achievementID, UTF8_TO_TCHAR(err->GetName()), UTF8_TO_TCHAR(err->GetMsg()));
-			return false;
+			success = false;
+			continue;
 		}
 
 		auto title{FText::FromString(UTF8_TO_TCHAR(achievementInfoBuffer.data()))};
@@ -409,7 +411,8 @@ bool FOnlineAchievementsGOG::UpdateAchievementDescriptions()
 		if (err)
 		{
 			UE_LOG_ONLINE_ACHIEVEMENTS(Error, TEXT("Failed to read achievement description: achievementID='%s'; %s; %s"), *achievementID, UTF8_TO_TCHAR(err->GetName()), UTF8_TO_TCHAR(err->GetMsg()));
-			return false;
+			success = false;
+			continue;
 		}
 
 		auto description{FText::FromString(UTF8_TO_TCHAR(achievementInfoBuffer.data()))};
@@ -419,7 +422,8 @@ bool FOnlineAchievementsGOG::UpdateAchievementDescriptions()
 		if (err)
 		{
 			UE_LOG_ONLINE_ACHIEVEMENTS(Error, TEXT("Failed to get achievement visibility: achievementID='%s'; %s; %s"), *achievementID, UTF8_TO_TCHAR(err->GetName()), UTF8_TO_TCHAR(err->GetMsg()));
-			return false;
+			success = false;
+			continue;
 		}
 
 		cachedAchievementDescriptions.Emplace(
@@ -427,5 +431,5 @@ bool FOnlineAchievementsGOG::UpdateAchievementDescriptions()
 			FOnlineAchievementDesc{MoveTemp(title), description, description, isHidden});
 	}
 
-	return true;
+	return success;
 }


### PR DESCRIPTION
In the past two years I've ported 4 or 5 UE4 games from Steam to GOG. After importing the achievements in the backend I usually copy/paste the achievements list from the OnlineSubsystemSteam section of DefaultGame.ini to the OnlineSubsystemGOG section.

Sometimes, a few achievements in the list do not exist in the backend, most likely because the achievements were dropped at some point during the development of the game.

Currently the GOG OSS will stop the initialization of the achievements as soon as one achievement fails to init, in my case because it does not exist in the backend. Meaning only the achievements that were initialized before the first error will work correctly. All other achievements won't work (i.e. not possible to unlock them).

Of course it would be better to remove the unused achievements from the list when possible but sometimes it goes unnoticed. I've been bitten by this issue myself recently and that was not the first time, so I'm opening this PR hoping it won't happen again (to me or anyone else) :)